### PR TITLE
Increase log information + supports groups transmitted as a string

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -243,6 +243,11 @@ class auth_plugin_authssocas extends AuthPlugin
             }
         }
 
+        # Always add the default group (as done by other auth plugins)
+        if ($conf['defaultgroup'] && !in_array($conf['defaultgroup'], $user_groups)) {
+             array_push($user_groups, $conf['defaultgroup']);
+        }
+
         return $user_groups;
     }
     /**

--- a/auth.php
+++ b/auth.php
@@ -197,7 +197,7 @@ class auth_plugin_authssocas extends AuthPlugin
         if (phpCAS::isAuthenticated() or ($this->getOption('autologin') and phpCAS::checkAuthentication())) {
 
             $USERINFO = $this->cas_user_attributes(phpCAS::getAttributes());
-            $this->auth_log($USERINFO['uid']);
+            $this->auth_log($USERINFO);
             $_SESSION[DOKU_COOKIE]['auth']['user'] = $USERINFO['uid'];
             $_SESSION[DOKU_COOKIE]['auth']['info'] = $USERINFO;
             $_SERVER['REMOTE_USER'] = $USERINFO['uid'];
@@ -228,18 +228,18 @@ class auth_plugin_authssocas extends AuthPlugin
      *
      * Log user connection if the log file is defined
      *
-     * format : DATE|TIME|USER
+     * format : DATE|TIME|USER|USERINFO
      *
-     * @param $user
+     * @param $userinfo (dict)
      * @return void
      */
-    private function auth_log($user): void
+    private function auth_log($userinfo): void
     {
         if (!is_null($this->logfileuser)) {
 
             $date = (new DateTime('now'))->format('Ymd|H:i:s');
 
-            $userline = $date . "|" . $user . PHP_EOL;
+            $userline = $date . "|" . $userinfo['uid'] . '|' . json_encode($userinfo) . PHP_EOL;
             if (!io_saveFile($this->logfileuser, $userline, true)) {
                 msg($this->getLang('writefail'), -1);
             }

--- a/auth.php
+++ b/auth.php
@@ -69,6 +69,7 @@ class auth_plugin_authssocas extends AuthPlugin
         $this->options['rootcas'] = $this->getConf('rootcas');
         $this->options['uid_attribut'] = $this->getConf('uid_attribut');
         $this->options['cacert'] = $this->getConf('cacert');
+        $this->options['http_header_real_ip'] = $this->getConf('http_header_real_ip');
 
         $server_version = CAS_VERSION_2_0;
         if ($this->getOption("samlValidate")) {
@@ -228,7 +229,7 @@ class auth_plugin_authssocas extends AuthPlugin
      *
      * Log user connection if the log file is defined
      *
-     * format : DATE|TIME|USER|USERINFO
+     * format : DATE|TIME|USER|CLIENT_IP|REAL_CLIENT_IP|USERINFO
      *
      * @param $userinfo (dict)
      * @return void
@@ -239,7 +240,11 @@ class auth_plugin_authssocas extends AuthPlugin
 
             $date = (new DateTime('now'))->format('Ymd|H:i:s');
 
-            $userline = $date . "|" . $userinfo['uid'] . '|' . json_encode($userinfo) . PHP_EOL;
+            $userline = $date . "|" . 
+                    $userinfo['uid'] . '|' . 
+                    $_SERVER['REMOTE_ADDR'] . '|' . 
+                    ( $this->getOption('http_header_real_ip') ? ( $_SERVER[$this->getOption('http_header_real_ip')]?: '-' ) : '-' )  . '|' .
+                    json_encode($userinfo) . PHP_EOL;
             if (!io_saveFile($this->logfileuser, $userline, true)) {
                 msg($this->getLang('writefail'), -1);
             }

--- a/conf/default.php
+++ b/conf/default.php
@@ -7,6 +7,7 @@ $conf['rootcas'] = '/cas';
 $conf['port'] = '443';
 $conf['samlValidate'] = 0;
 $conf['debug'] = 0;
+$conf['http_header_real_ip'] = 'HTTP_X_FORWARDED_FOR';
 
 $conf['handlelogoutrequest'] = 0;
 $conf['handlelogoutrequestTrustedHosts'] = '';
@@ -17,3 +18,4 @@ $conf['group_attribut'] = 'groups';
 $conf['name_attribut'] = 'displayName';
 $conf['mail_attribut'] = 'mail';
 $conf['uid_attribut'] = 'uid';
+

--- a/conf/default.php
+++ b/conf/default.php
@@ -15,6 +15,7 @@ $conf['handlelogoutrequestTrustedHosts'] = '';
 $conf['autologin'] = 0;
 
 $conf['group_attribut'] = 'groups';
+$conf['group_attribut_separator'] = '';
 $conf['name_attribut'] = 'displayName';
 $conf['mail_attribut'] = 'mail';
 $conf['uid_attribut'] = 'uid';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -16,6 +16,7 @@ $meta['handlelogoutrequestTrustedHosts'] = array('string');
 $meta['autologin'] = array('onoff');
 
 $meta['group_attribut'] = array('string');
+$meta['group_attribut_separator'] = array('string');
 $meta['name_attribut'] = array('string');
 $meta['mail_attribut'] = array('string');
 $meta['uid_attribut'] = array('string');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,6 +8,7 @@ $meta['rootcas'] = array('string');
 $meta['port'] = array('string');
 
 $meta['logfileuser'] = array('string');
+$meta['http_header_real_ip'] = array('string');
 
 $meta['handlelogoutrequest'] = array('onoff');
 $meta['handlelogoutrequestTrustedHosts'] = array('string');
@@ -22,3 +23,4 @@ $meta['uid_attribut'] = array('string');
 //$meta['force_redirect'] = array('onoff');
 $meta['debug'] = array('onoff');
 $meta['cacert'] = array('');
+

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -7,6 +7,7 @@ $lang['port'] = 'CAS server port (443)';
 $lang['rootcas'] = 'CAS server uri (/cas)';
 
 $lang['logfileuser'] = 'Log file name. If defined, log connections. The file is located in the logs folder. Time is in UTC';
+$lang['http_header_real_ip'] = 'HTTP header with the real client\'s IP address. Use this if dokuwiki instance is reverse proxy-fied';
 
 $lang['samlValidate'] = '??';
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -19,6 +19,7 @@ $lang['handlelogoutrequestTrustedHosts'] = 'trusted hosts for logout requests(FQ
 $lang['autologin'] = 'login automatically';
 
 $lang['group_attribut'] = 'CAS attribute containing list of user groups.';
+$lang['group_attribut_separator'] = 'By default, the groupe attribute is supposed to be an array. If the attribute is a string containing all the groups, specify here the group separator (i.e. comma, colum, semicolon, ...)';
 $lang['name_attribut'] = 'CAS attribute containing user name';
 $lang['mail_attribut'] = 'CAS attribute containing user mail';
 $lang['uid_attribut'] = 'CAS attribute containing user uid';

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -15,6 +15,7 @@ $lang['handlelogoutrequestTrustedHosts'] = 'Hôtes de confiance pour les demande
 $lang['autologin'] = 'Connexion automatique';
 
 $lang['group_attribut'] = 'Attribut CAS contenant la liste des groupes de l\'utilisateurs.';
+$lang['group_attribut_separator'] = 'Par défaut, l\'attribut du groupe est sensé être un tableau. Si l\'attribut est une chaîne contenant tous les groupes, donnez ici le séparateur des groupes (par ex. virgule, point-virgule, ...)';
 $lang['name_attribut'] = 'Attribut CAS contenant le nom de l\'utilisateur.';
 $lang['mail_attribut'] = 'Attribut CAS contenant le courriel de l\'utilisateur.';
 $lang['uid_attribut'] = 'Attribut CAS contenant l\'identifiant de l\'utilisateur.';

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -6,7 +6,7 @@ $lang['server'] = 'fqdn du serveur cas (cas.example.com)';
 $lang['port'] = 'port du CAS (443)';
 $lang['rootcas'] = 'URI du service cas (/cas)';
 $lang['logfileuser'] = 'Nom du fichier journal. Si définit, enregistre les connexions des utilisateurs. Le fichier se trouve le dossier des journaux. L\'heure est en UTC';
-
+$lang['http_header_real_ip'] = 'En-tête HTTP contenant l\'adresse IP réelle du client. A utiliser si l\'instance dokuwiki est "derrière" un serveur mandataire inverse (reverse proxy)';
 
 
 $lang['handlelogoutrequest'] = 'Gérer les demandes de déconnexion du CAS';


### PR DESCRIPTION
The log generated by the plugin now contains the client IP (both the REMOTE_ADDR and another header possibly added by a reverse proxy -- name of the header defined in the configuration), plus the full info provided by CAS

The group attribute coming from CAS can also be a string, with a separator defined in the configuration.

Also, always add the default group configured in the general dokuwiki configuration.

Not fully tested as my CAS server doeus not send the group membership as an array.